### PR TITLE
Fix to specify File.open

### DIFF
--- a/lib/stl_parser.rb
+++ b/lib/stl_parser.rb
@@ -163,7 +163,7 @@ class STLParser
   def process(infilename)
     resetVariables()
 
-    @f = open(infilename, "rb")
+    @f = File.open(infilename, "rb")
 
     # Set the file type to ascii if needed
     binary_found = false


### PR DESCRIPTION
When using with live_paper gem, line 168  "@f = open(infilename, "rb")" resolved to the wrong open. Easiest fix is to specify File.open.